### PR TITLE
chore(build): don't drop v from version

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -2,7 +2,7 @@ import mill.define.Target
 import mill.util.Jvm
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
 import $ivy.`io.github.davidgregory084::mill-tpolecat::0.3.1`
-import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.1.4`
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.2.0`
 
 import os.Path
 import mill._
@@ -275,9 +275,8 @@ trait JsonRPCModule extends ScalaModule with PublishModule with scalafmt.Scalafm
   def fmt() = T.command(reformat())
   def refreshedEnv = T.input(T.ctx().env)
   def publishVersion = T {
-    if (refreshedEnv().contains("CI")) {
-      VcsVersion.vcsState().format().drop("v".length)
-    } else "dev"
+    if (refreshedEnv().contains("CI")) VcsVersion.vcsState().format()
+    else "dev"
   }
   override def scalacOptions = T {
     super.scalacOptions() ++ Tpolecat.scalacOptionsFor(scalaVersion())


### PR DESCRIPTION
Dropping `v` inside of the version tag is now done by default
in the new version of mill-vcs-version -- https://github.com/lefou/mill-vcs-version/releases/tag/0.2.0
