### PR TITLE
fix(ci): ensure -i comes first

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         mill-version: 0.10.7
 
     - name: Publish
-      run: mill -j 0 -k -i --disable-ticker io.kipp.mill.ci.release.ReleaseModule/publishAll
+      run: mill -i -j 0 -k --disable-ticker io.kipp.mill.ci.release.ReleaseModule/publishAll
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         mill-version: 0.10.7
 
     - name: Publish
-      run: mill -i -j 0 -k --disable-ticker io.kipp.mill.ci.release.ReleaseModule/publishAll
+      run: mill -i -j 0 --disable-ticker io.kipp.mill.ci.release.ReleaseModule/publishAll
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
Screwed this up before.

The release attempt failed with 

> io.kipp.mill.ci.release.ReleaseModule.setupEnv Missing PGP_SECRET. Make sure you have it set.

I pull this from:

```
        PGP_SECRET: ${{ secrets.PGP_SECRET }}
```
Can you also double check that `secrets.PGP_SECRET` is correct?