### PR TITLE
fix parsing header

### DIFF
--- a/fs2/src/jsonrpclib/fs2/lsp.scala
+++ b/fs2/src/jsonrpclib/fs2/lsp.scala
@@ -56,7 +56,7 @@ object lsp {
     line.trim() match {
       case s"Content-Length: ${integer(length)}" =>
         Right(headers.copy(contentLength = length))
-      case s"Content-type: ${mimeType}; charset=${charset}" =>
+      case s"Content-Type: ${mimeType}; charset=${charset}" =>
         Right(
           headers.copy(mimeType = mimeType, charset = Charset.forName(charset))
         )


### PR DESCRIPTION
"Content-type" -> "Content-Type" according to https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#headerPart

I would also remove "to" from the error message "Couldn't parse to header: ...", wdyt? 