### PR TITLE
Revise endpoint and channel constructs to facilitate proxyfication

### DIFF
--- a/core/src/jsonrpclib/Endpoint.scala
+++ b/core/src/jsonrpclib/Endpoint.scala
@@ -15,7 +15,7 @@ object Endpoint {
     def apply[In, Err, Out](
         run: In => F[Either[Err, Out]]
     )(implicit inCodec: Codec[In], errCodec: ErrorCodec[Err], outCodec: Codec[Out]): Endpoint[F] =
-      RequestResponseEndpoint(method, (_: Method, in) => run(in), inCodec, errCodec, outCodec)
+      RequestResponseEndpoint(method, (_: Method, in: In) => run(in), inCodec, errCodec, outCodec)
 
     def full[In, Err, Out](
         run: (Method, In) => F[Either[Err, Out]]
@@ -33,7 +33,7 @@ object Endpoint {
       )
 
     def notification[In](run: In => F[Unit])(implicit inCodec: Codec[In]): Endpoint[F] =
-      NotificationEndpoint(method, (_: Method, in) => run(in), inCodec)
+      NotificationEndpoint(method, (_: Method, in: In) => run(in), inCodec)
 
     def notificationFull[In](run: (Method, In) => F[Unit])(implicit inCodec: Codec[In]): Endpoint[F] =
       NotificationEndpoint(method, run, inCodec)

--- a/core/src/jsonrpclib/Message.scala
+++ b/core/src/jsonrpclib/Message.scala
@@ -1,17 +1,16 @@
 package jsonrpclib
-package internals
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
 
 sealed trait Message { def maybeCallId: Option[CallId] }
-private[jsonrpclib] sealed trait InputMessage extends Message { def method: String }
-private[jsonrpclib] sealed trait OutputMessage extends Message {
+sealed trait InputMessage extends Message { def method: String }
+sealed trait OutputMessage extends Message {
   def callId: CallId; final override def maybeCallId: Option[CallId] = Some(callId)
 }
 
-private[jsonrpclib] object InputMessage {
+object InputMessage {
   case class RequestMessage(method: String, callId: CallId, params: Option[Payload]) extends InputMessage {
     def maybeCallId: Option[CallId] = Some(callId)
   }
@@ -19,8 +18,7 @@ private[jsonrpclib] object InputMessage {
     def maybeCallId: Option[CallId] = None
   }
 }
-
-private[jsonrpclib] object OutputMessage {
+object OutputMessage {
   def errorFrom(callId: CallId, protocolError: ProtocolError): OutputMessage =
     ErrorMessage(callId, ErrorPayload(protocolError.code, protocolError.getMessage(), None))
 
@@ -28,7 +26,7 @@ private[jsonrpclib] object OutputMessage {
   case class ResponseMessage(callId: CallId, data: Payload) extends OutputMessage
 }
 
-private[jsonrpclib] object Message {
+object Message {
 
   implicit val messageJsonValueCodecs: JsonValueCodec[Message] = new JsonValueCodec[Message] {
     val rawMessageCodec = implicitly[JsonValueCodec[internals.RawMessage]]

--- a/core/src/jsonrpclib/internals/MessageDispatcher.scala
+++ b/core/src/jsonrpclib/internals/MessageDispatcher.scala
@@ -77,13 +77,13 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
     (input, endpoint) match {
       case (InputMessage.NotificationMessage(_, params), ep: NotificationEndpoint[F, in]) =>
         ep.inCodec.decode(params) match {
-          case Right(value) => ep.run(value)
+          case Right(value) => ep.run(input.method, value)
           case Left(value)  => reportError(params, value, ep.method)
         }
       case (InputMessage.RequestMessage(_, callId, params), ep: RequestResponseEndpoint[F, in, err, out]) =>
         ep.inCodec.decode(params) match {
           case Right(value) =>
-            doFlatMap(ep.run(value)) {
+            doFlatMap(ep.run(input.method, value)) {
               case Right(data) =>
                 val responseData = ep.outCodec.encode(data)
                 sendMessage(OutputMessage.ResponseMessage(callId, responseData))

--- a/core/src/jsonrpclib/internals/MessageDispatcher.scala
+++ b/core/src/jsonrpclib/internals/MessageDispatcher.scala
@@ -1,11 +1,10 @@
 package jsonrpclib
 package internals
 
-import jsonrpclib.internals._
 import jsonrpclib.Endpoint.NotificationEndpoint
 import jsonrpclib.Endpoint.RequestResponseEndpoint
-import jsonrpclib.internals.OutputMessage.ErrorMessage
-import jsonrpclib.internals.OutputMessage.ResponseMessage
+import jsonrpclib.OutputMessage.ErrorMessage
+import jsonrpclib.OutputMessage.ResponseMessage
 import scala.util.Try
 
 private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F]) extends Channel.MonadicChannel[F] {
@@ -41,8 +40,8 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
       }
   }
 
-  protected[jsonrpclib] def handleReceivedPayload(payload: Payload): F[Unit] = {
-    Codec.decode[Message](Some(payload)).map {
+  protected[jsonrpclib] def handleReceivedMessage(message: Message): F[Unit] = {
+    message match {
       case im: InputMessage =>
         doFlatMap(getEndpoint(im.method)) {
           case Some(ep) => background(im.maybeCallId, executeInputMessage(im, ep))
@@ -61,29 +60,25 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
           case Some(pendingCall) => pendingCall(om)
           case None              => doPure(()) // TODO do something
         }
-    } match {
-      case Left(error) =>
-        sendProtocolError(error)
-      case Right(dispatch) => dispatch
     }
   }
 
-  private def sendProtocolError(callId: CallId, pError: ProtocolError): F[Unit] =
+  protected def sendProtocolError(callId: CallId, pError: ProtocolError): F[Unit] =
     sendMessage(OutputMessage.errorFrom(callId, pError))
-  private def sendProtocolError(pError: ProtocolError): F[Unit] =
+  protected def sendProtocolError(pError: ProtocolError): F[Unit] =
     sendProtocolError(CallId.NullId, pError)
 
   private def executeInputMessage(input: InputMessage, endpoint: Endpoint[F]): F[Unit] = {
     (input, endpoint) match {
       case (InputMessage.NotificationMessage(_, params), ep: NotificationEndpoint[F, in]) =>
         ep.inCodec.decode(params) match {
-          case Right(value) => ep.run(input.method, value)
+          case Right(value) => ep.run(input, value)
           case Left(value)  => reportError(params, value, ep.method)
         }
       case (InputMessage.RequestMessage(_, callId, params), ep: RequestResponseEndpoint[F, in, err, out]) =>
         ep.inCodec.decode(params) match {
           case Right(value) =>
-            doFlatMap(ep.run(input.method, value)) {
+            doFlatMap(ep.run(input, value)) {
               case Right(data) =>
                 val responseData = ep.outCodec.encode(data)
                 sendMessage(OutputMessage.ResponseMessage(callId, responseData))

--- a/examples/client/src/examples/client/ClientMain.scala
+++ b/examples/client/src/examples/client/ClientMain.scala
@@ -41,8 +41,8 @@ object ClientMain extends IOApp.Simple {
       // Creating a channel that will be used to communicate to the server
       fs2Channel <- FS2Channel[IO](cancelTemplate = cancelEndpoint.some)
       _ <- Stream(())
-        .concurrently(fs2Channel.output.through(lsp.encodePayloads).through(rp.stdin))
-        .concurrently(rp.stdout.through(lsp.decodePayloads).through(fs2Channel.input))
+        .concurrently(fs2Channel.output.through(lsp.encodeMessages).through(rp.stdin))
+        .concurrently(rp.stdout.through(lsp.decodeMessages).through(fs2Channel.inputOrBounce))
         .concurrently(rp.stderr.through(fs2.io.stderr[IO]))
       // Creating a `IntWrapper => IO[IntWrapper]` stub that can call the server
       increment = fs2Channel.simpleStub[IntWrapper, IntWrapper]("increment")

--- a/examples/server/src/examples/server/ServerMain.scala
+++ b/examples/server/src/examples/server/ServerMain.scala
@@ -34,8 +34,8 @@ object ServerMain extends IOApp.Simple {
         .flatMap(channel =>
           fs2.Stream
             .eval(IO.never) // running the server forever
-            .concurrently(stdin[IO](512).through(lsp.decodePayloads).through(channel.input))
-            .concurrently(channel.output.through(lsp.encodePayloads).through(stdout[IO]))
+            .concurrently(stdin[IO](512).through(lsp.decodeMessages).through(channel.inputOrBounce))
+            .concurrently(channel.output.through(lsp.encodeMessages).through(stdout[IO]))
         )
         .compile
         .drain


### PR DESCRIPTION
* Make the `Message` construct a public one. 
* Channels have input/output streams work at the Message level (higher level) as opposed to Payload (lower level). This should facilitate implementation of proxies. 
* Change the endpoints so that their `run` methods carry the original `InputMessage` in addition to the decoded payload. This allows for implementors of endpoints to just forward the `Message` to some other JsonRPC component (like, a client talking to a proxied server). 
* Allow for endpoints to be declared with glob patterns. 

This is both binary and source breaking, and will require a bump in minor. 