### PR TITLE
Remove jsonRpcPayload hint after use

### DIFF
--- a/modules/smithy4s/src/main/scala/jsonrpclib/smithy4sinterop/JsonPayloadTransformation.scala
+++ b/modules/smithy4s/src/main/scala/jsonrpclib/smithy4sinterop/JsonPayloadTransformation.scala
@@ -13,7 +13,9 @@ private[jsonrpclib] object JsonPayloadTransformation extends (Schema ~> Schema) 
         struct.fields
           .collectFirst {
             case field if field.hints.has[JsonRpcPayload] =>
-              field.schema.biject[b]((f: Any) => struct.make(Vector(f)))(field.get)
+              field.schema
+                .transformHintsLocally(_.filterNot(_.keyId == JsonRpcPayload.id))
+                .biject[b]((f: Any) => struct.make(Vector(f)))(field.get)
           }
           .getOrElse(fa)
       case _ => fa

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 
-addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.37")
+addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.38")
 
 addDependencyTreePlugin


### PR DESCRIPTION
After we've transformed the schema, the hint is no longer valid and should be removed, lest it be misinterpreted by something down the line.

This isn't really causing any issues that I've seen, but it seems like the right thing to do.