### PR TITLE
Enable mima against 0.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val commonSettings = Seq(
     "com.disneystreaming" %%% "weaver-cats" % "0.8.4" % Test
   ),
   mimaPreviousArtifacts := Set(
-    // organization.value %%% name.value % "0.0.7"
+    organization.value %%% name.value % "0.1.0"
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
We should really be doing transitive mima checks (sbt-typelevel can set this up for us), but it's a start.