### PR TITLE
Only use smithy4s-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ val smithy4s = projectMatrix
     commonSettings,
     mimaPreviousArtifacts := Set.empty,
     libraryDependencies ++= Seq(
-      "com.disneystreaming.smithy4s" %%% "smithy4s-json" % smithy4sVersion.value
+      "com.disneystreaming.smithy4s" %%% "smithy4s-core" % smithy4sVersion.value
     ),
     buildTimeProtocolDependency
   )


### PR DESCRIPTION
We don't use smithy4s-json because we actually do our encoding via Document instead.