### PR TITLE
Accept omitted `params` per JSON-RPC 2.0 §4

### DIFF
--- a/modules/core/src/main/scala/jsonrpclib/Message.scala
+++ b/modules/core/src/main/scala/jsonrpclib/Message.scala
@@ -11,11 +11,11 @@ sealed trait OutputMessage extends Message {
 }
 
 object InputMessage {
-  case class RequestMessage(method: String, callId: CallId, params: Option[Payload]) extends InputMessage {
+  case class RequestMessage(method: String, callId: CallId, params: Payload) extends InputMessage {
     def maybeCallId: Option[CallId] = Some(callId)
   }
 
-  case class NotificationMessage(method: String, params: Option[Payload]) extends InputMessage {
+  case class NotificationMessage(method: String, params: Payload) extends InputMessage {
     def maybeCallId: Option[CallId] = None
   }
 

--- a/modules/core/src/main/scala/jsonrpclib/Payload.scala
+++ b/modules/core/src/main/scala/jsonrpclib/Payload.scala
@@ -11,6 +11,7 @@ case class Payload(data: Json) {
 object Payload {
 
   val NullPayload: Payload = Payload(Json.Null)
+  val Empty: Payload = Payload(Json.obj())
 
   implicit val payloadEncoder: Encoder[Payload] = Encoder[Json].contramap(_.data)
   implicit val payloadDecoder: Decoder[Payload] = Decoder[Json].map(Payload(_))

--- a/modules/core/src/main/scala/jsonrpclib/internals/MessageDispatcher.scala
+++ b/modules/core/src/main/scala/jsonrpclib/internals/MessageDispatcher.scala
@@ -26,7 +26,7 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
 
   def notificationStub[In](method: String)(implicit inCodec: Encoder[In]): In => F[Unit] = { (input: In) =>
     val encoded = inCodec(input)
-    val message = InputMessage.NotificationMessage(method, Some(Payload(encoded)))
+    val message = InputMessage.NotificationMessage(method, Payload(encoded))
     sendMessage(message)
   }
 
@@ -36,7 +36,7 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
     (input: In) =>
       val encoded = inCodec(input)
       doFlatMap(nextCallId()) { callId =>
-        val message = InputMessage.RequestMessage(method, callId, Some(Payload(encoded)))
+        val message = InputMessage.RequestMessage(method, callId, Payload(encoded))
         doFlatMap(createPromise[Either[Err, Out]](callId)) { case (fulfill, future) =>
           val pc = createPendingCall(errDecoder, outCodec, fulfill)
           doFlatMap(storePendingCall(callId, pc))(_ => doFlatMap(sendMessage(message))(_ => future()))
@@ -74,12 +74,12 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
 
   private def executeInputMessage(input: InputMessage, endpoint: Endpoint[F]): F[Unit] = {
     (input, endpoint) match {
-      case (InputMessage.NotificationMessage(_, Some(params)), ep: NotificationEndpoint[F, in]) =>
+      case (InputMessage.NotificationMessage(_, params), ep: NotificationEndpoint[F, in]) =>
         ep.inCodec(HCursor.fromJson(params.data)) match {
           case Right(value) => ep.run(input, value)
           case Left(value)  => reportError(Some(params), ProtocolError.ParseError(value.getMessage), ep.method)
         }
-      case (InputMessage.RequestMessage(_, callId, Some(params)), ep: RequestResponseEndpoint[F, in, err, out]) =>
+      case (InputMessage.RequestMessage(_, callId, params), ep: RequestResponseEndpoint[F, in, err, out]) =>
         ep.inCodec(HCursor.fromJson(params.data)) match {
           case Right(value) =>
             doFlatMap(doAttempt(ep.run(input, value))) {
@@ -97,14 +97,6 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
           case Left(pError) =>
             sendProtocolError(callId, ProtocolError.ParseError(pError.getMessage))
         }
-      case (InputMessage.NotificationMessage(_, None), _: NotificationEndpoint[F, in]) =>
-        val message = "Missing payload"
-        val pError = ProtocolError.InvalidRequest(message)
-        sendProtocolError(pError)
-      case (InputMessage.RequestMessage(_, callId, None), _: RequestResponseEndpoint[F, in, err, out]) =>
-        val message = "Missing payload"
-        val pError = ProtocolError.InvalidRequest(message)
-        sendProtocolError(callId, pError)
       case (InputMessage.NotificationMessage(_, _), ep: RequestResponseEndpoint[F, in, err, out]) =>
         val message = s"This ${ep.method} endpoint cannot process notifications, request is missing callId"
         val pError = ProtocolError.InvalidRequest(message)

--- a/modules/core/src/main/scala/jsonrpclib/internals/MessageDispatcher.scala
+++ b/modules/core/src/main/scala/jsonrpclib/internals/MessageDispatcher.scala
@@ -4,6 +4,7 @@ package internals
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.HCursor
+import io.circe.Json
 import jsonrpclib.Endpoint.NotificationEndpoint
 import jsonrpclib.Endpoint.RequestResponseEndpoint
 import jsonrpclib.OutputMessage.ErrorMessage
@@ -74,13 +75,15 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
 
   private def executeInputMessage(input: InputMessage, endpoint: Endpoint[F]): F[Unit] = {
     (input, endpoint) match {
-      case (InputMessage.NotificationMessage(_, Some(params)), ep: NotificationEndpoint[F, in]) =>
-        ep.inCodec(HCursor.fromJson(params.data)) match {
+      case (InputMessage.NotificationMessage(_, params), ep: NotificationEndpoint[F, in]) =>
+        val payload = normalizeParams(params)
+        ep.inCodec(HCursor.fromJson(payload.data)) match {
           case Right(value) => ep.run(input, value)
-          case Left(value)  => reportError(Some(params), ProtocolError.ParseError(value.getMessage), ep.method)
+          case Left(value)  => reportError(Some(payload), ProtocolError.ParseError(value.getMessage), ep.method)
         }
-      case (InputMessage.RequestMessage(_, callId, Some(params)), ep: RequestResponseEndpoint[F, in, err, out]) =>
-        ep.inCodec(HCursor.fromJson(params.data)) match {
+      case (InputMessage.RequestMessage(_, callId, params), ep: RequestResponseEndpoint[F, in, err, out]) =>
+        val payload = normalizeParams(params)
+        ep.inCodec(HCursor.fromJson(payload.data)) match {
           case Right(value) =>
             doFlatMap(doAttempt(ep.run(input, value))) {
               case Right(Right(data)) =>
@@ -97,14 +100,6 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
           case Left(pError) =>
             sendProtocolError(callId, ProtocolError.ParseError(pError.getMessage))
         }
-      case (InputMessage.NotificationMessage(_, None), _: NotificationEndpoint[F, in]) =>
-        val message = "Missing payload"
-        val pError = ProtocolError.InvalidRequest(message)
-        sendProtocolError(pError)
-      case (InputMessage.RequestMessage(_, callId, None), _: RequestResponseEndpoint[F, in, err, out]) =>
-        val message = "Missing payload"
-        val pError = ProtocolError.InvalidRequest(message)
-        sendProtocolError(callId, pError)
       case (InputMessage.NotificationMessage(_, _), ep: RequestResponseEndpoint[F, in, err, out]) =>
         val message = s"This ${ep.method} endpoint cannot process notifications, request is missing callId"
         val pError = ProtocolError.InvalidRequest(message)
@@ -115,6 +110,10 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
         sendProtocolError(callId, pError)
     }
   }
+
+  // JSON-RPC 2.0 §4: the `params` member MAY be omitted; treat omitted/null as `{}`.
+  private def normalizeParams(params: Option[Payload]): Payload =
+    params.flatMap(_.stripNull).getOrElse(Payload(Json.obj()))
 
   private def createPendingCall[Err, Out](
       errDecoder: ErrorDecoder[Err],

--- a/modules/core/src/main/scala/jsonrpclib/internals/MessageDispatcher.scala
+++ b/modules/core/src/main/scala/jsonrpclib/internals/MessageDispatcher.scala
@@ -4,7 +4,6 @@ package internals
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.HCursor
-import io.circe.Json
 import jsonrpclib.Endpoint.NotificationEndpoint
 import jsonrpclib.Endpoint.RequestResponseEndpoint
 import jsonrpclib.OutputMessage.ErrorMessage
@@ -75,15 +74,13 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
 
   private def executeInputMessage(input: InputMessage, endpoint: Endpoint[F]): F[Unit] = {
     (input, endpoint) match {
-      case (InputMessage.NotificationMessage(_, params), ep: NotificationEndpoint[F, in]) =>
-        val payload = normalizeParams(params)
-        ep.inCodec(HCursor.fromJson(payload.data)) match {
+      case (InputMessage.NotificationMessage(_, Some(params)), ep: NotificationEndpoint[F, in]) =>
+        ep.inCodec(HCursor.fromJson(params.data)) match {
           case Right(value) => ep.run(input, value)
-          case Left(value)  => reportError(Some(payload), ProtocolError.ParseError(value.getMessage), ep.method)
+          case Left(value)  => reportError(Some(params), ProtocolError.ParseError(value.getMessage), ep.method)
         }
-      case (InputMessage.RequestMessage(_, callId, params), ep: RequestResponseEndpoint[F, in, err, out]) =>
-        val payload = normalizeParams(params)
-        ep.inCodec(HCursor.fromJson(payload.data)) match {
+      case (InputMessage.RequestMessage(_, callId, Some(params)), ep: RequestResponseEndpoint[F, in, err, out]) =>
+        ep.inCodec(HCursor.fromJson(params.data)) match {
           case Right(value) =>
             doFlatMap(doAttempt(ep.run(input, value))) {
               case Right(Right(data)) =>
@@ -100,6 +97,14 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
           case Left(pError) =>
             sendProtocolError(callId, ProtocolError.ParseError(pError.getMessage))
         }
+      case (InputMessage.NotificationMessage(_, None), _: NotificationEndpoint[F, in]) =>
+        val message = "Missing payload"
+        val pError = ProtocolError.InvalidRequest(message)
+        sendProtocolError(pError)
+      case (InputMessage.RequestMessage(_, callId, None), _: RequestResponseEndpoint[F, in, err, out]) =>
+        val message = "Missing payload"
+        val pError = ProtocolError.InvalidRequest(message)
+        sendProtocolError(callId, pError)
       case (InputMessage.NotificationMessage(_, _), ep: RequestResponseEndpoint[F, in, err, out]) =>
         val message = s"This ${ep.method} endpoint cannot process notifications, request is missing callId"
         val pError = ProtocolError.InvalidRequest(message)
@@ -110,10 +115,6 @@ private[jsonrpclib] abstract class MessageDispatcher[F[_]](implicit F: Monadic[F
         sendProtocolError(callId, pError)
     }
   }
-
-  // JSON-RPC 2.0 §4: the `params` member MAY be omitted; treat omitted/null as `{}`.
-  private def normalizeParams(params: Option[Payload]): Payload =
-    params.flatMap(_.stripNull).getOrElse(Payload(Json.obj()))
 
   private def createPendingCall[Err, Out](
       errDecoder: ErrorDecoder[Err],

--- a/modules/core/src/main/scala/jsonrpclib/internals/RawMessage.scala
+++ b/modules/core/src/main/scala/jsonrpclib/internals/RawMessage.scala
@@ -17,9 +17,9 @@ private[jsonrpclib] case class RawMessage(
 
   def toMessage: Either[ProtocolError, Message] = (id, method) match {
     case (Some(callId), Some(method)) =>
-      Right(InputMessage.RequestMessage(method, callId, params))
+      Right(InputMessage.RequestMessage(method, callId, normalizedParams))
     case (None, Some(method)) =>
-      Right(InputMessage.NotificationMessage(method, params))
+      Right(InputMessage.NotificationMessage(method, normalizedParams))
     case (Some(callId), None) =>
       (error, result) match {
         case (Some(error), _) => Right(OutputMessage.ErrorMessage(callId, error))
@@ -38,6 +38,10 @@ private[jsonrpclib] case class RawMessage(
         )
       )
   }
+
+  // JSON-RPC 2.0 §4: the `params` member MAY be omitted; treat omitted/null as `{}`.
+  private def normalizedParams: Option[Payload] =
+    Some(params.flatMap(_.stripNull).getOrElse(Payload(Json.obj())))
 }
 
 private[jsonrpclib] object RawMessage {

--- a/modules/core/src/main/scala/jsonrpclib/internals/RawMessage.scala
+++ b/modules/core/src/main/scala/jsonrpclib/internals/RawMessage.scala
@@ -40,19 +40,24 @@ private[jsonrpclib] case class RawMessage(
   }
 
   // JSON-RPC 2.0 §4: the `params` member MAY be omitted; treat omitted/null as `{}`.
-  private def normalizedParams: Option[Payload] =
-    Some(params.flatMap(_.stripNull).getOrElse(Payload(Json.obj())))
+  private def normalizedParams: Payload =
+    params.flatMap(_.stripNull).getOrElse(Payload.Empty)
 }
 
 private[jsonrpclib] object RawMessage {
 
   val `2.0` = "2.0"
 
+  // Per JSON-RPC 2.0 §4, omitted and empty-object params are semantically equivalent;
+  // we elide the field on the wire to match what spec-compliant clients expect.
+  private def encodeParams(params: Payload): Option[Payload] =
+    if (params == Payload.Empty) None else Some(params)
+
   def from(message: Message): RawMessage = message match {
     case InputMessage.NotificationMessage(method, params) =>
-      RawMessage(`2.0`, method = Some(method), params = params)
+      RawMessage(`2.0`, method = Some(method), params = encodeParams(params))
     case InputMessage.RequestMessage(method, callId, params) =>
-      RawMessage(`2.0`, method = Some(method), params = params, id = Some(callId))
+      RawMessage(`2.0`, method = Some(method), params = encodeParams(params), id = Some(callId))
     case OutputMessage.ErrorMessage(callId, errorPayload) =>
       RawMessage(`2.0`, error = Some(errorPayload), id = Some(callId))
     case OutputMessage.ResponseMessage(callId, data) =>

--- a/modules/core/src/test/scala/jsonrpclib/RawMessageSpec.scala
+++ b/modules/core/src/test/scala/jsonrpclib/RawMessageSpec.scala
@@ -50,14 +50,13 @@ object RawMessageSpec extends FunSuite {
       .flatMap(_.toMessage.left.map(e => new RuntimeException(e.getMessage)))
       .fold(throw _, identity)
 
-    val emptyObj = Some(Payload(Json.obj()))
-    expect.same(omitted, InputMessage.RequestMessage("m", NumberId(1), emptyObj)) &&
-    expect.same(nulled, InputMessage.RequestMessage("m", NumberId(2), emptyObj)) &&
-    expect.same(notif, InputMessage.NotificationMessage("m", emptyObj))
+    expect.same(omitted, InputMessage.RequestMessage("m", NumberId(1), Payload.Empty)) &&
+    expect.same(nulled, InputMessage.RequestMessage("m", NumberId(2), Payload.Empty)) &&
+    expect.same(notif, InputMessage.NotificationMessage("m", Payload.Empty))
   }
 
-  test("request message serialization") {
-    val input: Message = InputMessage.RequestMessage("my/method", CallId.NumberId(1), None)
+  test("request message serialization elides empty params") {
+    val input: Message = InputMessage.RequestMessage("my/method", CallId.NumberId(1), Payload.Empty)
     val expected = """{"jsonrpc":"2.0","method":"my/method","id":1}"""
     val result = writeToString(input.asJson)
 
@@ -68,7 +67,7 @@ object RawMessageSpec extends FunSuite {
     val input: Message = InputMessage.RequestMessage(
       "greet",
       CallId.NumberId(0),
-      Some(Payload(Json.obj("name" -> Json.fromString("Client"))))
+      Payload(Json.obj("name" -> Json.fromString("Client")))
     )
     val expected = """{"jsonrpc":"2.0","method":"greet","params":{"name":"Client"},"id":0}"""
     val result = writeToString(input.asJson)
@@ -76,8 +75,8 @@ object RawMessageSpec extends FunSuite {
     expect(result == expected, s"Expected: $expected, got: $result")
   }
 
-  test("notification message serialization") {
-    val input: Message = InputMessage.NotificationMessage("my/method", None)
+  test("notification message serialization elides empty params") {
+    val input: Message = InputMessage.NotificationMessage("my/method", Payload.Empty)
     val expected = """{"jsonrpc":"2.0","method":"my/method"}"""
     val result = writeToString(input.asJson)
 

--- a/modules/core/src/test/scala/jsonrpclib/RawMessageSpec.scala
+++ b/modules/core/src/test/scala/jsonrpclib/RawMessageSpec.scala
@@ -33,6 +33,29 @@ object RawMessageSpec extends FunSuite {
     expect(invalidRawMessage.toMessage.isLeft, invalidRawMessage.toMessage.toString)
   }
 
+  test("request with omitted or null params decodes to empty object") {
+    // JSON-RPC 2.0 §4: the `params` member MAY be omitted.
+    val omitted = readFromString[Json]("""{"jsonrpc":"2.0","method":"m","id":1}""")
+      .as[RawMessage]
+      .flatMap(_.toMessage.left.map(e => new RuntimeException(e.getMessage)))
+      .fold(throw _, identity)
+
+    val nulled = readFromString[Json]("""{"jsonrpc":"2.0","method":"m","params":null,"id":2}""")
+      .as[RawMessage]
+      .flatMap(_.toMessage.left.map(e => new RuntimeException(e.getMessage)))
+      .fold(throw _, identity)
+
+    val notif = readFromString[Json]("""{"jsonrpc":"2.0","method":"m"}""")
+      .as[RawMessage]
+      .flatMap(_.toMessage.left.map(e => new RuntimeException(e.getMessage)))
+      .fold(throw _, identity)
+
+    val emptyObj = Some(Payload(Json.obj()))
+    expect.same(omitted, InputMessage.RequestMessage("m", NumberId(1), emptyObj)) &&
+    expect.same(nulled, InputMessage.RequestMessage("m", NumberId(2), emptyObj)) &&
+    expect.same(notif, InputMessage.NotificationMessage("m", emptyObj))
+  }
+
   test("request message serialization") {
     val input: Message = InputMessage.RequestMessage("my/method", CallId.NumberId(1), None)
     val expected = """{"jsonrpc":"2.0","method":"my/method","id":1}"""

--- a/modules/fs2/src/test/scala/jsonrpclib/fs2/FS2ChannelSpec.scala
+++ b/modules/fs2/src/test/scala/jsonrpclib/fs2/FS2ChannelSpec.scala
@@ -5,6 +5,7 @@ import cats.syntax.all._
 import fs2.Stream
 import io.circe.generic.semiauto._
 import io.circe.Codec
+import io.circe.Json
 import jsonrpclib._
 import weaver._
 
@@ -15,6 +16,11 @@ object FS2ChannelSpec extends SimpleIOSuite {
   case class IntWrapper(int: Int)
   object IntWrapper {
     implicit val codec: Codec[IntWrapper] = deriveCodec
+  }
+
+  case class NoArgs()
+  object NoArgs {
+    implicit val codec: Codec[NoArgs] = deriveCodec
   }
 
   case class CancelRequest(callId: CallId)
@@ -105,6 +111,58 @@ object FS2ChannelSpec extends SimpleIOSuite {
       val (time, results) = timedResults
       expect.same(results, (2 to 11).toList.map(IntWrapper(_))) &&
       expect(time < 2.seconds)
+    }
+  }
+
+  // JSON-RPC 2.0 §4 allows `params` to be omitted; the dispatcher must accept it
+  // for endpoints whose input decodes from an empty object.
+  testRes("Request with omitted params is accepted") {
+    val endpoint: Endpoint[IO] =
+      Endpoint[IO]("noargs").simple((_: NoArgs) => IO.pure(IntWrapper(42)))
+
+    for {
+      server <- FS2Channel.stream[IO]()
+      _ <- server.withEndpointStream(endpoint)
+      request: Message = InputMessage.RequestMessage("noargs", CallId.NumberId(1), None)
+      response <- server.output.take(1).concurrently(Stream.emit(request).through(server.input))
+    } yield {
+      response match {
+        case OutputMessage.ResponseMessage(CallId.NumberId(1), payload) =>
+          expect.same(payload.data.as[IntWrapper], Right(IntWrapper(42)))
+        case other => failure(s"Unexpected response: $other")
+      }
+    }
+  }
+
+  testRes("Request with null params is accepted") {
+    val endpoint: Endpoint[IO] =
+      Endpoint[IO]("noargs").simple((_: NoArgs) => IO.pure(IntWrapper(7)))
+
+    for {
+      server <- FS2Channel.stream[IO]()
+      _ <- server.withEndpointStream(endpoint)
+      request: Message = InputMessage.RequestMessage("noargs", CallId.NumberId(2), Some(Payload(Json.Null)))
+      response <- server.output.take(1).concurrently(Stream.emit(request).through(server.input))
+    } yield {
+      response match {
+        case OutputMessage.ResponseMessage(CallId.NumberId(2), payload) =>
+          expect.same(payload.data.as[IntWrapper], Right(IntWrapper(7)))
+        case other => failure(s"Unexpected response: $other")
+      }
+    }
+  }
+
+  testRes("Notification with omitted params is accepted") {
+    for {
+      received <- IO.deferred[NoArgs].toStream
+      endpoint: Endpoint[IO] = Endpoint[IO]("notify").notification((args: NoArgs) => received.complete(args).void)
+      server <- FS2Channel.stream[IO]()
+      _ <- server.withEndpointStream(endpoint)
+      notification: Message = InputMessage.NotificationMessage("notify", None)
+      _ <- Stream.emit(notification).through(server.input)
+      result <- received.get.toStream
+    } yield {
+      expect.same(result, NoArgs())
     }
   }
 

--- a/modules/fs2/src/test/scala/jsonrpclib/fs2/FS2ChannelSpec.scala
+++ b/modules/fs2/src/test/scala/jsonrpclib/fs2/FS2ChannelSpec.scala
@@ -2,6 +2,8 @@ package jsonrpclib.fs2
 
 import cats.effect.IO
 import cats.syntax.all._
+import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec._
+import com.github.plokhotnyuk.jsoniter_scala.core._
 import fs2.Stream
 import io.circe.generic.semiauto._
 import io.circe.Codec
@@ -114,16 +116,20 @@ object FS2ChannelSpec extends SimpleIOSuite {
     }
   }
 
-  // JSON-RPC 2.0 §4 allows `params` to be omitted; the dispatcher must accept it
-  // for endpoints whose input decodes from an empty object.
+  // JSON-RPC 2.0 §4 allows `params` to be omitted; wire-format parsing must accept
+  // such requests for endpoints whose input decodes from an empty object.
+  private def parseMessage(json: String): Message =
+    readFromString[Json](json).as[Message].fold(throw _, identity)
+
   testRes("Request with omitted params is accepted") {
     val endpoint: Endpoint[IO] =
       Endpoint[IO]("noargs").simple((_: NoArgs) => IO.pure(IntWrapper(42)))
 
+    val request = parseMessage("""{"jsonrpc":"2.0","method":"noargs","id":1}""")
+
     for {
       server <- FS2Channel.stream[IO]()
       _ <- server.withEndpointStream(endpoint)
-      request: Message = InputMessage.RequestMessage("noargs", CallId.NumberId(1), None)
       response <- server.output.take(1).concurrently(Stream.emit(request).through(server.input))
     } yield {
       response match {
@@ -138,10 +144,11 @@ object FS2ChannelSpec extends SimpleIOSuite {
     val endpoint: Endpoint[IO] =
       Endpoint[IO]("noargs").simple((_: NoArgs) => IO.pure(IntWrapper(7)))
 
+    val request = parseMessage("""{"jsonrpc":"2.0","method":"noargs","params":null,"id":2}""")
+
     for {
       server <- FS2Channel.stream[IO]()
       _ <- server.withEndpointStream(endpoint)
-      request: Message = InputMessage.RequestMessage("noargs", CallId.NumberId(2), Some(Payload(Json.Null)))
       response <- server.output.take(1).concurrently(Stream.emit(request).through(server.input))
     } yield {
       response match {
@@ -153,12 +160,13 @@ object FS2ChannelSpec extends SimpleIOSuite {
   }
 
   testRes("Notification with omitted params is accepted") {
+    val notification = parseMessage("""{"jsonrpc":"2.0","method":"notify"}""")
+
     for {
       received <- IO.deferred[NoArgs].toStream
       endpoint: Endpoint[IO] = Endpoint[IO]("notify").notification((args: NoArgs) => received.complete(args).void)
       server <- FS2Channel.stream[IO]()
       _ <- server.withEndpointStream(endpoint)
-      notification: Message = InputMessage.NotificationMessage("notify", None)
       _ <- Stream.emit(notification).through(server.input)
       result <- received.get.toStream
     } yield {


### PR DESCRIPTION
Fixes #104.

## Problem

Per JSON-RPC 2.0 §4 the `params` member MAY be omitted. The dispatcher
rejected any request whose `params` field was absent (or `null`) with
`-32600 InvalidRequest "Missing payload"`, making spec-compliant clients
unable to call parameterless methods (e.g. the official MCP TypeScript
SDK calling `tools/list`).

## Approach

1. **`Payload.Empty`** sentinel = `Payload(Json.obj())`.
2. **`RequestMessage.params` / `NotificationMessage.params`** change from
   `Option[Payload]` to `Payload` — `None` is no longer expressible.
3. **`RawMessage.toMessage`** normalizes an absent/null wire `params`
   to `Payload.Empty`.
4. **`RawMessage.from`** elides the `params` field on the wire when it
   equals `Payload.Empty` (spec treats omitted and `{}` as equivalent).
5. **`MessageDispatcher`** drops the now-impossible `None` branches —
   the pattern match shrinks from 6 cases to 4.

The earlier commits in this PR are intermediate iterations of the same
fix; happy to squash before merging.

## Binary compatibility

This is a **binary-breaking change** to public case-class signatures
(`InputMessage.RequestMessage` / `NotificationMessage`). MIMA isn't
configured with previous artifacts so CI won't catch it — worth calling
out in release notes / version bump.

## Test plan

- [x] `core/test` and `core3/test` — `RawMessageSpec` covers wire-layer
      decoding (omitted / null / notification) and serialization elision.
- [x] `fs2/test` and `fs23/test` — end-to-end tests via `FS2Channel`
      parsing raw JSON for the three relevant shapes.
- [x] `smithy4sTests/test` and `smithy4sTests3/test` — existing suite
      still green.
- [x] `scalafmtCheckAll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)