### PR TITLE
Expose codecs for `InputMessage` and `OutputMessage`

### DIFF
--- a/modules/core/src/main/scala/jsonrpclib/Message.scala
+++ b/modules/core/src/main/scala/jsonrpclib/Message.scala
@@ -2,6 +2,7 @@ package jsonrpclib
 
 import io.circe.syntax._
 import io.circe.Codec
+import io.circe.DecodingFailure
 
 sealed trait Message { def maybeCallId: Option[CallId] }
 sealed trait InputMessage extends Message { def method: String }
@@ -19,6 +20,13 @@ object InputMessage {
     def maybeCallId: Option[CallId] = None
   }
 
+  implicit val codec: Codec[InputMessage] = Codec.from(
+    Message.codec.emap {
+      case input: InputMessage => Right(input)
+      case _: OutputMessage    => Left("expected a JSON-RPC request or notification, got a response")
+    },
+    Message.codec.contramap[InputMessage](identity)
+  )
 }
 
 object OutputMessage {
@@ -28,6 +36,13 @@ object OutputMessage {
   case class ErrorMessage(callId: CallId, payload: ErrorPayload) extends OutputMessage
   case class ResponseMessage(callId: CallId, data: Payload) extends OutputMessage
 
+  implicit val codec: Codec[OutputMessage] = Codec.from(
+    Message.codec.emap {
+      case output: OutputMessage => Right(output)
+      case _: InputMessage       => Left("expected a JSON-RPC response, got a request or notification")
+    },
+    Message.codec.contramap[OutputMessage](identity)
+  )
 }
 
 object Message {
@@ -35,7 +50,7 @@ object Message {
 
   implicit val codec: Codec[Message] = Codec.from(
     { c =>
-      c.as[RawMessage].flatMap(_.toMessage.left.map(e => io.circe.DecodingFailure(e.getMessage, c.history)))
+      c.as[RawMessage].flatMap(_.toMessage.left.map(e => DecodingFailure(e.getMessage, c.history)))
     },
     RawMessage.from(_).asJson
   )

--- a/modules/core/src/test/scala/jsonrpclib/RawMessageSpec.scala
+++ b/modules/core/src/test/scala/jsonrpclib/RawMessageSpec.scala
@@ -89,4 +89,39 @@ object RawMessageSpec extends FunSuite {
     expect(result == expected, s"Expected: $expected, got: $result")
   }
 
+  test("input message codec decodes requests and notifications") {
+    def decodeInput(s: String) = readFromString[Json](s).as[InputMessage]
+
+    expect.same(
+      decodeInput("""{"jsonrpc":"2.0","method":"greet","id":1}"""),
+      Right(InputMessage.RequestMessage("greet", CallId.NumberId(1), None))
+    ) &&
+    expect.same(
+      decodeInput("""{"jsonrpc":"2.0","method":"ping"}"""),
+      Right(InputMessage.NotificationMessage("ping", None))
+    ) &&
+    expect(decodeInput("""{"jsonrpc":"2.0","id":1,"result":null}""").isLeft)
+  }
+
+  test("input message codec serializes via Message encoder") {
+    val input: InputMessage = InputMessage.RequestMessage("greet", CallId.NumberId(0), None)
+    val expected = """{"jsonrpc":"2.0","method":"greet","id":0}"""
+
+    expect(writeToString(input.asJson) == expected)
+  }
+
+  test("output message codec decodes responses and errors") {
+    def decodeOutput(s: String) = readFromString[Json](s).as[OutputMessage]
+
+    expect.same(
+      decodeOutput("""{"jsonrpc":"2.0","id":1,"result":null}"""),
+      Right(OutputMessage.ResponseMessage(CallId.NumberId(1), Payload.NullPayload))
+    ) &&
+    expect.same(
+      decodeOutput("""{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":null},"id":1}"""),
+      Right(OutputMessage.ErrorMessage(CallId.NumberId(1), ErrorPayload(-32603, "Internal error", None)))
+    ) &&
+    expect(decodeOutput("""{"jsonrpc":"2.0","method":"greet","id":1}""").isLeft)
+  }
+
 }


### PR DESCRIPTION
Lets users decode JSON-RPC payloads directly into the input/output variants without re-implementing a codec around the package-private `RawMessage`.